### PR TITLE
fix(ci): include only dynamic-weather-card.js in release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,13 +162,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
           body: ${{ steps.changelog.outputs.changelog }}
-          files: |
-            dynamic-weather-card.js
-            hacs.json
-            README.md
-            README.ru.md
-            LICENSE
-            CHANGELOG.md
+          files: dynamic-weather-card.js
           draft: false
           prerelease: false
           make_latest: true


### PR DESCRIPTION
## Summary

- Remove unnecessary files from release assets (hacs.json, README.md, README.ru.md, LICENSE, CHANGELOG.md)
- HACS only downloads the main JS file specified in hacs.json (filename field)
- Other files are read directly from the repository, not from release assets

## Test plan

- [ ] Create a test release and verify only dynamic-weather-card.js is attached