### PR TITLE
chore: release workflow dispatch only

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -2,19 +2,7 @@
 
 This project uses manual workflows for creating releases and managing changelogs.
 
-## Release Methods
-
-### Option 1: Manual Tag Creation
-
-1. Create and push a tag manually:
-   ```bash
-   git tag -a v0.2.2 -m "Release v0.2.2"
-   git push origin v0.2.2
-   ```
-
-2. The `release.yml` workflow will run automatically
-
-### Option 2: Manual Workflow Trigger
+## How to Release
 
 1. Go to GitHub Actions → Release workflow
 2. Click "Run workflow"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary
- Remove `push: tags` trigger from `release.yml`, keep only `workflow_dispatch`
- Prevents automatic overwrites of manually created releases (caused the v0.5.2 issue)
- Update `RELEASE.md` to reflect single release method