### PR TITLE
fix(types): derive config language union from available locales

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@
  * Type definitions for Home Assistant and Weather Card
  */
 
+import type { SupportedLanguage } from './internationalization/locales.generated';
+
 // Home Assistant Entity State
 export interface HassEntity {
   entity_id: string;
@@ -125,7 +127,7 @@ export interface WeatherCardConfig {
   clockPosition?: 'top' | 'details';
   clockFormat?: '12h' | '24h';
   overlayOpacity?: number;
-  language?: 'auto' | 'en' | 'ru' | 'de' | 'nl' | 'fr' | 'es' | 'it' | 'sk' | 'hu';
+  language?: 'auto' | SupportedLanguage;
   height?: number | null;
   windSpeedUnit?: 'ms' | 'kmh';
   showAnimations?: boolean;
@@ -218,7 +220,7 @@ export interface ConfigInput {
   clock_position?: 'top' | 'details';
   clock_format?: '12h' | '24h';
   overlay_opacity?: number;
-  language?: 'auto' | 'en' | 'ru' | 'de' | 'nl' | 'fr' | 'es' | 'it' | 'sk' | 'hu';
+  language?: 'auto' | SupportedLanguage;
   wind_speed_unit?: 'ms' | 'kmh';
   show_animations?: boolean;
   sunrise_entity?: string;


### PR DESCRIPTION
The `language` union in `WeatherCardConfig`/`ConfigInput` was hardcoded to the pre-July language list and rejected `pt`/`da`/`sr`/`pl` at the type level. Now derived from the generated `SupportedLanguage` union, so new locales are picked up automatically. Type-only change — bundle unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)